### PR TITLE
changed uboot stdout and stdin to uart0

### DIFF
--- a/arch/arm/dts/piksiv3_evt2.dts
+++ b/arch/arm/dts/piksiv3_evt2.dts
@@ -13,7 +13,7 @@
 	compatible = "xlnx,zynq-piksiv3-evt2", "xlnx,zynq-7000";
 
 	aliases {
-		serial0 = &uart1;
+		serial0 = &uart0;
 		spi0 = &qspi;
 		mmc0 = &sdhci0;
 	};


### PR DESCRIPTION
for evt2 for compatibility with manufacture test board
