### PR TITLE
Updated factory data

### DIFF
--- a/board/xilinx/zynq/board.c
+++ b/board/xilinx/zynq/board.c
@@ -44,7 +44,7 @@ static xilinx_desc fpga100 = XILINX_XC7Z100_DESC(0x100);
 #ifndef CONFIG_TPL_BUILD
 static struct {
   uint32_t hardware;
-  uint32_t serial_number;
+  char uuid[17];
   uint8_t mac_address[6];
 } factory_params;
 
@@ -101,9 +101,9 @@ static int factory_params_read(void)
     return -1;
   }
 
-  if (factory_data_serial_number_get(factory_data,
-                                     &factory_params.serial_number) != 0) {
-    puts("Error reading serial number from factory data\n");
+  if (factory_data_uuid_get(factory_data,
+                                     &factory_params.uuid) != 0) {
+    puts("Error reading manufacturer serial number from factory data\n");
     return -1;
   }
 
@@ -296,9 +296,9 @@ int board_late_init(void)
   }
 
   /* Set serial number environment variable */
-  char buf[16];
-  snprintf(buf, sizeof(buf), "%d", factory_params.serial_number);
-  setenv("serial_number", buf);
+  char buf[17];
+  snprintf(buf, sizeof(buf), "%s", factory_params.uuid);
+  setenv("uuid", buf);
 #endif
 #endif
 

--- a/board/xilinx/zynq/board.c
+++ b/board/xilinx/zynq/board.c
@@ -44,7 +44,7 @@ static xilinx_desc fpga100 = XILINX_XC7Z100_DESC(0x100);
 #ifndef CONFIG_TPL_BUILD
 static struct {
   uint32_t hardware;
-  char uuid[17];
+  uint8_t uuid[16];
   uint8_t mac_address[6];
 } factory_params;
 
@@ -102,8 +102,8 @@ static int factory_params_read(void)
   }
 
   if (factory_data_uuid_get(factory_data,
-                                     &factory_params.uuid) != 0) {
-    puts("Error reading manufacturer serial number from factory data\n");
+                                     factory_params.uuid) != 0) {
+    puts("Error reading uuid from factory data\n");
     return -1;
   }
 
@@ -295,7 +295,7 @@ int board_late_init(void)
 #endif
   }
 
-  /* Set serial number environment variable */
+  /* Set uuid environment variable */
   char buf[17];
   snprintf(buf, sizeof(buf), "%s", factory_params.uuid);
   setenv("uuid", buf);

--- a/board/xilinx/zynq/board.c
+++ b/board/xilinx/zynq/board.c
@@ -102,7 +102,7 @@ static int factory_params_read(void)
   }
 
   if (factory_data_uuid_get(factory_data,
-                                     factory_params.uuid) != 0) {
+                            factory_params.uuid) != 0) {
     puts("Error reading uuid from factory data\n");
     return -1;
   }

--- a/board/xilinx/zynq/board.c
+++ b/board/xilinx/zynq/board.c
@@ -48,6 +48,14 @@ static struct {
   uint8_t mac_address[6];
 } factory_params;
 
+static void print_hex_string(char *str, const uint8_t *data, uint32_t data_size)
+{
+  uint32_t i;
+  for (i = 0; i < data_size; i++) {
+    str += sprintf(str, "%02x", data[data_size - 1 - i]);
+  }
+}
+
 static int factory_params_read(void)
 {
   int err = 0;
@@ -296,8 +304,8 @@ int board_late_init(void)
   }
 
   /* Set uuid environment variable */
-  char buf[17];
-  snprintf(buf, sizeof(buf), "%s", factory_params.uuid);
+  char buf[sizeof(factory_params.uuid) * 2 + 1];
+  print_hex_string(buf, factory_params.uuid, sizeof(factory_params.uuid));
   setenv("uuid", buf);
 #endif
 #endif

--- a/common/factory_data.c
+++ b/common/factory_data.c
@@ -52,11 +52,13 @@ int factory_data_populate(factory_data_t *f, const factory_data_params_t *p)
   memset((void *)f, FACTORY_DATA_RESERVED_BYTE, sizeof(*f) + sizeof(*b));
 
   /* populate body */
-  b->_hardware =            cpu_to_le32(p->hardware);
-  b->_serial_number =       cpu_to_le32(p->serial_number);
-  b->_timestamp =           cpu_to_le32(p->timestamp);
-  memcpy(b->_nap_key,       p->nap_key,       sizeof(b->_nap_key));
-  memcpy(b->_mac_address,   p->mac_address,   sizeof(b->_mac_address));
+  b->_hardware =                cpu_to_le32(p->hardware);
+  memcpy(b->_mfg_serial_number, p->mfg_serial_number, sizeof(b->_mfg_serial_number));
+  memcpy(b->_uuid,              p->uuid,              sizeof(b->_uuid));
+  b->_timestamp =               cpu_to_le32(p->timestamp);
+  memcpy(b->_nap_key,           p->nap_key,           sizeof(b->_nap_key));
+  memcpy(b->_mac_address,       p->mac_address,       sizeof(b->_mac_address));
+  b->_factory_stage =           cpu_to_le32(p->factory_stage);
 
   /* compute body crc */
   uint32_t body_crc = crc32(0, (const unsigned char *)b, sizeof(*b));

--- a/common/factory_data.c
+++ b/common/factory_data.c
@@ -52,13 +52,13 @@ int factory_data_populate(factory_data_t *f, const factory_data_params_t *p)
   memset((void *)f, FACTORY_DATA_RESERVED_BYTE, sizeof(*f) + sizeof(*b));
 
   /* populate body */
-  b->_hardware =                cpu_to_le32(p->hardware);
-  memcpy(b->_mfg_serial_number, p->mfg_serial_number, sizeof(b->_mfg_serial_number));
-  memcpy(b->_uuid,              p->uuid,              sizeof(b->_uuid));
-  b->_timestamp =               cpu_to_le32(p->timestamp);
-  memcpy(b->_nap_key,           p->nap_key,           sizeof(b->_nap_key));
-  memcpy(b->_mac_address,       p->mac_address,       sizeof(b->_mac_address));
-  b->_factory_stage =           cpu_to_le32(p->factory_stage);
+  b->_hardware =            cpu_to_le32(p->hardware);
+  memcpy(b->_mfg_id,        p->mfg_id,        sizeof(b->_mfg_id));
+  memcpy(b->_uuid,          p->uuid,          sizeof(b->_uuid));
+  b->_timestamp =           cpu_to_le32(p->timestamp);
+  memcpy(b->_nap_key,       p->nap_key,       sizeof(b->_nap_key));
+  memcpy(b->_mac_address,   p->mac_address,   sizeof(b->_mac_address));
+  b->_factory_stage =       cpu_to_le32(p->factory_stage);
 
   /* compute body crc */
   uint32_t body_crc = crc32(0, (const unsigned char *)b, sizeof(*b));

--- a/include/configs/piksiv3_dev.h
+++ b/include/configs/piksiv3_dev.h
@@ -187,7 +187,7 @@
     "netboot=" \
       "run net_disable_gigabit && " \
       "dhcp && " \
-      "tftpboot ${kernel_load_address} PK${serial_number}/${kernel_image} && " \
+      "tftpboot ${kernel_load_address} PK${uuid}/${kernel_image} && " \
       "env set bootargs ${bootargs} dev_boot=net && " \
       "env set bootargs ${bootargs} ip=" \
         "${ipaddr}:${serverip}:${gatewayip}:${netmask}:${hostname}::off && " \

--- a/include/factory_data.h
+++ b/include/factory_data.h
@@ -21,7 +21,7 @@
  * - Data: variable size, fields may be appended but never removed
  */
 
-#define FACTORY_DATA_SIGNATURE 0xcb1e6082
+#define FACTORY_DATA_SIGNATURE 0x8e54ae38
 #define FACTORY_DATA_RESERVED_BYTE 0xff
 
 #define FACTORY_STAGE_UNKNOWN        0xffffffff

--- a/include/factory_data.h
+++ b/include/factory_data.h
@@ -28,10 +28,12 @@
  * Do not access fields directly. Use API functions only. */
 typedef struct {
   uint32_t _hardware;
-  uint32_t _serial_number;
+  uint8_t _mfg_serial_number[17];
+  uint8_t _uuid[16];
   uint32_t _timestamp;
   uint8_t  _nap_key[16];
   uint8_t  _mac_address[6];
+  uint32_t _factory_stage;
   uint8_t  _reserved0[2];
 } factory_data_body_t;
 
@@ -46,10 +48,12 @@ typedef struct {
 
 typedef struct {
   uint32_t hardware;
-  uint32_t serial_number;
+  uint8_t mfg_serial_number[17];
+  uint8_t uuid[16];
   uint32_t timestamp;
   uint8_t nap_key[16];
   uint8_t mac_address[6];
+  uint32_t factory_stage;
 } factory_data_params_t;
 
 static inline uint32_t factory_data_body_size_get(const factory_data_t *f) {
@@ -83,10 +87,12 @@ static inline uint32_t factory_data_body_size_get(const factory_data_t *f) {
   }
 
 FACTORY_DATA_GET_U32_FN(hardware);
-FACTORY_DATA_GET_U32_FN(serial_number);
+FACTORY_DATA_GET_ARRAY_FN(mfg_serial_number);
+FACTORY_DATA_GET_ARRAY_FN(uuid);
 FACTORY_DATA_GET_U32_FN(timestamp);
 FACTORY_DATA_GET_ARRAY_FN(nap_key);
 FACTORY_DATA_GET_ARRAY_FN(mac_address);
+FACTORY_DATA_GET_U32_FN(factory_stage);
 
 int factory_data_header_verify(const factory_data_t *f);
 int factory_data_body_verify(const factory_data_t *f);

--- a/include/factory_data.h
+++ b/include/factory_data.h
@@ -24,17 +24,25 @@
 #define FACTORY_DATA_SIGNATURE 0xcb1e6082
 #define FACTORY_DATA_RESERVED_BYTE 0xff
 
+#define FACTORY_STAGE_UNKNOWN        0xffffffff
+#define FACTORY_STAGE_INITIAL        0x00000000
+#define FACTORY_STAGE_POST_BURN_IN   0x00000001
+#define FACTORY_STAGE_HOST_BOARD     0x00000002
+#define FACTORY_STAGE_RETURN         0x00000003
+#define FACTORY_STAGE_DEV            0x00000004
+
 /* Warning: factory data structures use unspecified endianness.
  * Do not access fields directly. Use API functions only. */
 typedef struct {
   uint32_t _hardware;
-  uint8_t _mfg_serial_number[17];
+  uint8_t _mfg_id[17];
+  uint8_t  _reserved0[3];
   uint8_t _uuid[16];
   uint32_t _timestamp;
   uint8_t  _nap_key[16];
   uint8_t  _mac_address[6];
+  uint8_t  _reserved1[2];
   uint32_t _factory_stage;
-  uint8_t  _reserved0[2];
 } factory_data_body_t;
 
 typedef struct {
@@ -48,7 +56,7 @@ typedef struct {
 
 typedef struct {
   uint32_t hardware;
-  uint8_t mfg_serial_number[17];
+  uint8_t mfg_id[17];
   uint8_t uuid[16];
   uint32_t timestamp;
   uint8_t nap_key[16];
@@ -87,7 +95,7 @@ static inline uint32_t factory_data_body_size_get(const factory_data_t *f) {
   }
 
 FACTORY_DATA_GET_U32_FN(hardware);
-FACTORY_DATA_GET_ARRAY_FN(mfg_serial_number);
+FACTORY_DATA_GET_ARRAY_FN(mfg_id);
 FACTORY_DATA_GET_ARRAY_FN(uuid);
 FACTORY_DATA_GET_U32_FN(timestamp);
 FACTORY_DATA_GET_ARRAY_FN(nap_key);

--- a/include/image_table.h
+++ b/include/image_table.h
@@ -31,6 +31,7 @@
 #define IMAGE_HARDWARE_MICROZED   0x00000001
 #define IMAGE_HARDWARE_EVT1       0x00000011
 #define IMAGE_HARDWARE_EVT2       0x00000012
+#define IMAGE_HARDWARE_DVT        0x00000013
 
 /* Warning: image_set_t and image_descriptor_t use unspecified endianness.
  * Do not access fields directly. Use API functions only. */

--- a/include/image_table.h
+++ b/include/image_table.h
@@ -31,7 +31,7 @@
 #define IMAGE_HARDWARE_MICROZED   0x00000001
 #define IMAGE_HARDWARE_EVT1       0x00000011
 #define IMAGE_HARDWARE_EVT2       0x00000012
-#define IMAGE_HARDWARE_DVT        0x00000013
+#define IMAGE_HARDWARE_DVT1       0x00000013
 
 /* Warning: image_set_t and image_descriptor_t use unspecified endianness.
  * Do not access fields directly. Use API functions only. */

--- a/tools/factory_data_util.c
+++ b/tools/factory_data_util.c
@@ -227,7 +227,7 @@ static int parse_options(int argc, char *argv[])
       break;
 
       case 'u': {
-         if (parse_hex_string(optarg, args.factory_data_params.uuid,
+        if (parse_hex_string(optarg, args.factory_data_params.uuid,
                              sizeof(args.factory_data_params.uuid)) != 0) {
           fprintf(stderr, "invalid uuid: \"%s\"\n", optarg);
           return -1;

--- a/tools/factory_data_util.c
+++ b/tools/factory_data_util.c
@@ -53,6 +53,7 @@ static const struct {
   { IMAGE_HARDWARE_MICROZED,    "microzed"  },
   { IMAGE_HARDWARE_EVT1,        "evt1"      },
   { IMAGE_HARDWARE_EVT2,        "evt2"      },
+  { IMAGE_HARDWARE_DVT,         "dvt"       },
 };
 
 static void usage(void)


### PR DESCRIPTION
removed serial number from factory data and added mfg serial number, uuid, and factory stage

Needs to coordinate with:
https://github.com/swift-nav/piksi_buildroot/pull/49
https://github.com/swift-nav/piksi_firmware_private/pull/317

The manufacturing serial number will conform to https://docs.google.com/presentation/d/15EZuzpCQQhy4v1kI91kMINtdHDqRaDI8Zp46qBmnAuo/edit#slide=id.g19019de0f4_0_5 and the uuid will be used to derive the sender ID

@jacobmcnamee @mfine 