### PR TITLE
Improve TPL bootstrap detection, implement for EVT1+

### DIFF
--- a/arch/arm/mach-zynq/Makefile
+++ b/arch/arm/mach-zynq/Makefile
@@ -13,6 +13,7 @@ obj-y	+= cpu.o
 obj-y	+= ddrc.o
 obj-y	+= slcr.o
 obj-y	+= clk.o
+obj-y	+= gpio.o
 obj-y	+= lowlevel_init.o
 AFLAGS_lowlevel_init.o := -mfpu=neon
 obj-$(CONFIG_SPL_BUILD)	+= spl.o

--- a/arch/arm/mach-zynq/gpio.c
+++ b/arch/arm/mach-zynq/gpio.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <common.h>
+#include <asm/io.h>
+#include <asm/arch/hardware.h>
+#include <asm/arch/sys_proto.h>
+#include <asm/arch/clk.h>
+
+void zynq_gpio_cfg_input(unsigned gpio)
+{
+  u32 reg;
+
+  /* Clear DIRM bit */
+  reg = readl(&gpio_base->cfg[gpio / 32].dirm);
+  reg &= ~(1 << (gpio % 32));
+  writel(reg, &gpio_base->cfg[gpio / 32].dirm);
+
+  /* Clear OEN bit */
+  reg = readl(&gpio_base->cfg[gpio / 32].oen);
+  reg &= ~(1 << (gpio % 32));
+  writel(reg, &gpio_base->cfg[gpio / 32].oen);
+}
+
+void zynq_gpio_cfg_output(unsigned gpio)
+{
+  u32 reg;
+
+  /* Set DIRM bit */
+  reg = readl(&gpio_base->cfg[gpio / 32].dirm);
+  reg |= (1 << (gpio % 32));
+  writel(reg, &gpio_base->cfg[gpio / 32].dirm);
+
+  /* Set OEN bit */
+  reg = readl(&gpio_base->cfg[gpio / 32].oen);
+  reg |= (1 << (gpio % 32));
+  writel(reg, &gpio_base->cfg[gpio / 32].oen);
+}
+
+int zynq_gpio_input_read(unsigned gpio)
+{
+  /* Read DATA_RO bit */
+  return (readl(&gpio_base->data_ro[gpio / 32]) >> (gpio % 32)) & 0x1;
+}
+
+void zynq_gpio_output_write(unsigned gpio, unsigned value)
+{
+  u32 reg;
+
+  /* Write DATA bit */
+  reg = readl(&gpio_base->data[gpio / 32]);
+  reg = (reg & ~(1 << (gpio % 32))) | ((value & 0x1) << (gpio % 32));
+  writel(reg, &gpio_base->data[gpio / 32]);
+}

--- a/arch/arm/mach-zynq/include/mach/hardware.h
+++ b/arch/arm/mach-zynq/include/mach/hardware.h
@@ -21,6 +21,7 @@
 #define ZYNQ_EFUSE_BASEADDR		0xF800D000
 #define ZYNQ_USB_BASEADDR0		0xE0002000
 #define ZYNQ_USB_BASEADDR1		0xE0003000
+#define ZYNQ_GPIO_BASEADDR		0xE000A000
 
 /* Bootmode setting values */
 #define ZYNQ_BM_MASK		0x7
@@ -138,5 +139,31 @@ struct efuse_reg {
 };
 
 #define efuse_base ((struct efuse_reg *)ZYNQ_EFUSE_BASEADDR)
+
+struct gpio_regs {
+  struct {
+    u32 lsw;
+    u32 msw;
+  } mask_data[4];
+  u32 reserved0[8];
+  u32 data[4];
+  u32 reserved1[4];
+  u32 data_ro[4];
+  u32 reserved2[101];
+  struct {
+    u32 dirm;
+    u32 oen;
+    u32 int_mask;
+    u32 int_en;
+    u32 int_dis;
+    u32 int_stat;
+    u32 int_type;
+    u32 int_polarity;
+    u32 int_any;
+    u32 reserved3[7];
+  } cfg[4];
+};
+
+#define gpio_base ((struct gpio_regs *)ZYNQ_GPIO_BASEADDR)
 
 #endif /* _ASM_ARCH_HARDWARE_H */

--- a/arch/arm/mach-zynq/include/mach/sys_proto.h
+++ b/arch/arm/mach-zynq/include/mach/sys_proto.h
@@ -21,6 +21,11 @@ extern unsigned int zynq_get_silicon_version(void);
 
 int zynq_board_read_rom_ethaddr(unsigned char *ethaddr);
 
+void zynq_gpio_cfg_input(unsigned gpio);
+void zynq_gpio_cfg_output(unsigned gpio);
+int zynq_gpio_input_read(unsigned gpio);
+void zynq_gpio_output_write(unsigned gpio, unsigned value);
+
 /* Driver extern functions */
 extern void ps7_init(void);
 

--- a/include/configs/piksiv3_evt1_prod.h
+++ b/include/configs/piksiv3_evt1_prod.h
@@ -19,14 +19,10 @@
 
 #ifdef CONFIG_TPL_BUILD
 
-/* Bootstrap pin configuration - nothing to do */
-#define CONFIG_TPL_BOOTSTRAP_INIT
-
-/* not implemented */
-#define CONFIG_TPL_BOOTSTRAP_FAILSAFE false
-
-/* not implemented */
-#define CONFIG_TPL_BOOTSTRAP_ALTERNATE false
+#define CONFIG_TPL_BOOTSTRAP_RX0_MIO 10
+#define CONFIG_TPL_BOOTSTRAP_TX0_MIO 11
+#define CONFIG_TPL_BOOTSTRAP_RX1_MIO 13
+#define CONFIG_TPL_BOOTSTRAP_TX1_MIO 12
 
 #endif
 

--- a/include/configs/piksiv3_evt2_prod.h
+++ b/include/configs/piksiv3_evt2_prod.h
@@ -19,14 +19,10 @@
 
 #ifdef CONFIG_TPL_BUILD
 
-/* Bootstrap pin configuration - nothing to do */
-#define CONFIG_TPL_BOOTSTRAP_INIT
-
-/* not implemented */
-#define CONFIG_TPL_BOOTSTRAP_FAILSAFE false
-
-/* not implemented */
-#define CONFIG_TPL_BOOTSTRAP_ALTERNATE false
+#define CONFIG_TPL_BOOTSTRAP_RX0_MIO 10
+#define CONFIG_TPL_BOOTSTRAP_TX0_MIO 11
+#define CONFIG_TPL_BOOTSTRAP_RX1_MIO 13
+#define CONFIG_TPL_BOOTSTRAP_TX1_MIO 12
 
 #endif
 

--- a/include/configs/piksiv3_microzed_prod.h
+++ b/include/configs/piksiv3_microzed_prod.h
@@ -19,16 +19,11 @@
 
 #ifdef CONFIG_TPL_BUILD
 
-/* Bootstrap pin configuration - nothing to do */
-#define CONFIG_TPL_BOOTSTRAP_INIT
-
-/* MIO 51 = SW1, default low */
-#define CONFIG_TPL_BOOTSTRAP_FAILSAFE \
-  ((readl(0xE000A064) & (1<<19)) ? true : false)
-
-/* MIO 47 = LED, default low */
-#define CONFIG_TPL_BOOTSTRAP_ALTERNATE \
-  ((readl(0xE000A064) & (1<<15)) ? true : false)
+/* Write to MIO 8 = unused, read from LED */
+#define CONFIG_TPL_BOOTSTRAP_RX0_MIO 47
+#define CONFIG_TPL_BOOTSTRAP_TX0_MIO 47
+#define CONFIG_TPL_BOOTSTRAP_RX1_MIO 47
+#define CONFIG_TPL_BOOTSTRAP_TX1_MIO  8
 
 #endif
 


### PR DESCRIPTION
Short `UART0_TX` to `UART1_TX` to enable reading bootstrap config from UART RX pins. For normal boot a short low pulse on `UART1_TX` will be observed.

Bench tested on EVT2. TX0 to TX1 pin connection works well and as expected. When not connected, the only observable behavior is a ~10us low pulse on TX1.

Fallback ("alt") and failsafe mechanisms work as expected.

/cc @swift-nav/firmware 