### PR TITLE
Workaround for TPL icache issue: Do not place SPL code in lower 40kB RAM

### DIFF
--- a/include/configs/piksiv3_dev.h
+++ b/include/configs/piksiv3_dev.h
@@ -372,11 +372,10 @@
 /* for booting directly linux */
 #define CONFIG_SPL_OS_BOOT
 
-/* SP location before relocation, must use scratch RAM */
-#define CONFIG_SPL_TEXT_BASE  0x0
-
-/* 3 * 64kB blocks of OCM - one is on the top because of bootrom */
-#define CONFIG_SPL_MAX_SIZE 0x30000
+/* SPL code */
+/* Workaround for TPL icache issue: Do not place code in lower 40kB */
+#define CONFIG_SPL_TEXT_BASE      0x0000a000
+#define CONFIG_SPL_MAX_SIZE       0x00026000
 
 /* The highest 64k OCM address */
 #define OCM_HIGH_ADDR 0xffff0000

--- a/include/configs/piksiv3_failsafe.h
+++ b/include/configs/piksiv3_failsafe.h
@@ -323,11 +323,10 @@
 /* for booting directly linux */
 #define CONFIG_SPL_OS_BOOT
 
-/* SP location before relocation, must use scratch RAM */
-#define CONFIG_SPL_TEXT_BASE  0x0
-
-/* 3 * 64kB blocks of OCM - one is on the top because of bootrom */
-#define CONFIG_SPL_MAX_SIZE 0x30000
+/* SPL code */
+/* Workaround for TPL icache issue: Do not place code in lower 40kB */
+#define CONFIG_SPL_TEXT_BASE      0x0000a000
+#define CONFIG_SPL_MAX_SIZE       0x00026000
 
 /* The highest 64k OCM address */
 #define OCM_HIGH_ADDR 0xffff0000

--- a/include/configs/piksiv3_prod.h
+++ b/include/configs/piksiv3_prod.h
@@ -186,11 +186,12 @@
 /* SPL is loaded to low OCM, no relocation */
 /* 192kB code in low OCM */
 /* 8kB heap, 8kB bss, 48kB stack in high OCM */
+/* Workaround for TPL icache issue: Do not place code in lower 40kB */
 
 #define CONFIG_SPL_LDSCRIPT "arch/arm/mach-zynq/u-boot-spl.lds"
 
-#define CONFIG_SPL_TEXT_BASE              0x00000000
-#define CONFIG_SPL_MAX_SIZE               0x00030000
+#define CONFIG_SPL_TEXT_BASE              0x0000a000
+#define CONFIG_SPL_MAX_SIZE               0x00026000
 
 #define CONFIG_SYS_SPL_MALLOC_START       0xffff0000
 #define CONFIG_SYS_SPL_MALLOC_SIZE        0x00002000


### PR DESCRIPTION
TPL code is originally loaded and executed at address 0x0. Since the icache is enabled and never flushed, this can cause problems when SPL code is also loaded and executed at address 0x0. Work around this issue by simply not placing SPL code in the TPL code region.

A more sophisticated workaround could begin SPL execution outside the TPL code region and flush the icache before executing code inside the TPL code region. This is not presently necessary as SPL code size is not constrained.

/cc @swift-nav/firmware 