### PR TITLE
Added hardware revision to factory data

### DIFF
--- a/common/factory_data.c
+++ b/common/factory_data.c
@@ -59,6 +59,7 @@ int factory_data_populate(factory_data_t *f, const factory_data_params_t *p)
   memcpy(b->_nap_key,       p->nap_key,       sizeof(b->_nap_key));
   memcpy(b->_mac_address,   p->mac_address,   sizeof(b->_mac_address));
   b->_factory_stage =       cpu_to_le32(p->factory_stage);
+  b->_hardware_revision =   cpu_to_le32(p->hardware_revision);
 
   /* compute body crc */
   uint32_t body_crc = crc32(0, (const unsigned char *)b, sizeof(*b));

--- a/include/factory_data.h
+++ b/include/factory_data.h
@@ -43,6 +43,7 @@ typedef struct {
   uint8_t  _mac_address[6];
   uint8_t  _reserved1[2];
   uint32_t _factory_stage;
+  uint32_t _hardware_revision;
 } factory_data_body_t;
 
 typedef struct {
@@ -62,6 +63,7 @@ typedef struct {
   uint8_t nap_key[16];
   uint8_t mac_address[6];
   uint32_t factory_stage;
+  uint32_t hardware_revision;
 } factory_data_params_t;
 
 static inline uint32_t factory_data_body_size_get(const factory_data_t *f) {
@@ -101,6 +103,7 @@ FACTORY_DATA_GET_U32_FN(timestamp);
 FACTORY_DATA_GET_ARRAY_FN(nap_key);
 FACTORY_DATA_GET_ARRAY_FN(mac_address);
 FACTORY_DATA_GET_U32_FN(factory_stage);
+FACTORY_DATA_GET_U32_FN(hardware_revision);
 
 int factory_data_header_verify(const factory_data_t *f);
 int factory_data_body_verify(const factory_data_t *f);

--- a/tools/factory_data_util.c
+++ b/tools/factory_data_util.c
@@ -99,8 +99,8 @@ static void usage(void)
   for (i=0; i<ARRAY_SIZE(factory_stage_strings); i++) {
     printf("%s ", factory_stage_strings[i].name);
   }
-  puts("\t-r, --hw-rev <hw-rev>");
-  puts("\t\tdeximal hardware revision in the form ((major_rev << 16) | minor_rev)");
+  puts("\t-r, --hardware-revision <hardware-revision>");
+  puts("\t\thardware revision in the form ((major_rev << 16) | minor_rev)");
 
   puts("\nMisc options");
   puts("\t--verify <file>");
@@ -185,7 +185,7 @@ static int parse_options(int argc, char *argv[])
     {"nap-key",           required_argument, 0, 'k'},
     {"mac-address",       required_argument, 0, 'm'},
     {"factory-stage",     required_argument, 0, 'f'},
-    {"hw-rev",            required_argument, 0, 'r'},
+    {"hardware-revision", required_argument, 0, 'r'},
     {"verify",            required_argument, 0, OPT_ID_VERIFY},
     {"print",             no_argument,       0, 'p'},
     {0, 0, 0, 0}

--- a/tools/factory_data_util.c
+++ b/tools/factory_data_util.c
@@ -42,6 +42,7 @@ static struct {
     .nap_key = {0},
     .mac_address = {0},
     .factory_stage = 0,
+    .hardware_revision = 0,
   }
 };
 
@@ -98,6 +99,8 @@ static void usage(void)
   for (i=0; i<ARRAY_SIZE(factory_stage_strings); i++) {
     printf("%s ", factory_stage_strings[i].name);
   }
+  puts("\t-r, --hw-rev <hw-rev>");
+  puts("\t\tdeximal hardware revision in the form ((major_rev << 16) | minor_rev)");
 
   puts("\nMisc options");
   puts("\t--verify <file>");
@@ -182,6 +185,7 @@ static int parse_options(int argc, char *argv[])
     {"nap-key",           required_argument, 0, 'k'},
     {"mac-address",       required_argument, 0, 'm'},
     {"factory-stage",     required_argument, 0, 'f'},
+    {"hw-rev",            required_argument, 0, 'r'},
     {"verify",            required_argument, 0, OPT_ID_VERIFY},
     {"print",             no_argument,       0, 'p'},
     {0, 0, 0, 0}
@@ -189,7 +193,7 @@ static int parse_options(int argc, char *argv[])
 
   int c;
   int opt_index;
-  while ((c = getopt_long(argc, argv, "o:h:i:u:t:k:m:f:p",
+  while ((c = getopt_long(argc, argv, "o:h:i:u:t:k:m:f:r:p",
                           long_opts, &opt_index)) != -1) {
     switch (c) {
       case 'o': {
@@ -271,6 +275,11 @@ static int parse_options(int argc, char *argv[])
           }
         }
 
+        case 'r': {
+          args.factory_data_params.hardware_revision = strtol(optarg, NULL, 0);
+        }
+        break;
+
         if (!found) {
           fprintf(stderr, "invalid factory stage: \"%s\"\n", optarg);
           return -1;
@@ -348,6 +357,13 @@ static void factory_data_print(const factory_data_t *f)
   uint32_t factory_stage;
   if (factory_data_timestamp_get(f, &factory_stage) == 0) {
     printf("Factory Stage:  %08x\n", factory_stage);
+  }
+
+  uint32_t hardware_revision;
+  if (factory_data_hardware_revision_get(f, &hardware_revision) == 0) {
+    uint16_t major = hardware_revision >> 16;
+    uint16_t minor = hardware_revision;
+    printf("Hardware Rev:   %u.%u\n", major, minor);
   }
 }
 


### PR DESCRIPTION
It's represented has a u32 with most significant two bytes coding the major revision and the lower two bytes coding the minor revision. The mfg-id will be used to determine the part number and this hardware revision will be used to check for any version specific hardware capabilities.

@soulcmdc @jacobmcnamee 