### PR TITLE
libfdt include fix

### DIFF
--- a/include/fdt_support.h
+++ b/include/fdt_support.h
@@ -10,7 +10,7 @@
 
 #ifdef CONFIG_OF_LIBFDT
 
-#include <libfdt.h>
+#include "libfdt.h"
 
 u32 fdt_getprop_u32_default_node(const void *fdt, int off, int cell,
 				const char *prop, const u32 dflt);

--- a/include/fdtdec.h
+++ b/include/fdtdec.h
@@ -14,7 +14,7 @@
  * changes to support FDT are minimized.
  */
 
-#include <libfdt.h>
+#include "libfdt.h"
 #include <pci.h>
 
 /*

--- a/include/libfdt.h
+++ b/include/libfdt.h
@@ -51,8 +51,8 @@
  *     EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <libfdt_env.h>
-#include <fdt.h>
+#include "libfdt_env.h"
+#include "fdt.h"
 
 #define FDT_FIRST_SUPPORTED_VERSION	0x10
 #define FDT_LAST_SUPPORTED_VERSION	0x11

--- a/tools/fdtgrep.c
+++ b/tools/fdtgrep.c
@@ -16,8 +16,8 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <../include/libfdt.h>
-#include <libfdt_internal.h>
+#include "../include/libfdt.h"
+#include "libfdt_internal.h"
 
 /* Define DEBUG to get some debugging output on stderr */
 #ifdef DEBUG


### PR DESCRIPTION
This enables building with buildroot 2018.02 with the newer uboot-tools package versions.

The issue was that u-boot includes a local version of libfdt and has a bug in the way the headers for this local version are included. This wasn't an issue until newer versions of uboot-tools started installing a system version of libfdt which conflicts with the local one. This same kind of fix has been applied in a much more recent version of u-boot but I'm backporting the fix here for convenience.

See also:
https://github.com/u-boot/u-boot/commit/b95a5190ba9284a06f9d0c56589bcb4080b4710a

cc: @silverjam @jck @gsmcmullin