### PR TITLE
Erase flash before boot, disable JTAG [DEVC-290]

### DIFF
--- a/arch/arm/mach-zynq/cpu.c
+++ b/arch/arm/mach-zynq/cpu.c
@@ -38,6 +38,18 @@ int arch_cpu_init(void)
 	zynq_clk_early_init();
 	zynq_slcr_lock();
 
+#ifdef  CONFIG_DISABLE_ZYNQ_DEBUG
+
+#define DAP_ENABLE_MASK 0x7F
+#define JTAG_CHAIN_DISABLE 0x00800000
+
+  unsigned int control = readl(&devcfg_base->ctrl);
+  control &= ~DAP_ENABLE_MASK;
+  control |= JTAG_CHAIN_DISABLE;
+
+  writel(control, &devcfg_base->ctrl);
+#endif
+
 	return 0;
 }
 

--- a/common/Makefile
+++ b/common/Makefile
@@ -86,6 +86,7 @@ endif
 ifdef CONFIG_POST
 obj-$(CONFIG_CMD_DIAG) += cmd_diag.o
 endif
+obj-$(CONFIG_CMD_DISABLE_JTAG) += cmd_disable_jtag.o
 obj-$(CONFIG_CMD_DISPLAY) += cmd_display.o
 obj-$(CONFIG_CMD_DTT) += cmd_dtt.o
 obj-$(CONFIG_CMD_ECHO) += cmd_echo.o
@@ -93,6 +94,7 @@ obj-$(CONFIG_ENV_IS_IN_EEPROM) += cmd_eeprom.o
 obj-$(CONFIG_CMD_EEPROM) += cmd_eeprom.o
 obj-$(CONFIG_EFI_STUB) += cmd_efi.o
 obj-$(CONFIG_CMD_ELF) += cmd_elf.o
+obj-$(CONFIG_CMD_ENABLE_JTAG) += cmd_enable_jtag.o
 obj-$(CONFIG_SYS_HUSH_PARSER) += cmd_exit.o
 obj-$(CONFIG_CMD_EXT4) += cmd_ext4.o
 obj-$(CONFIG_CMD_EXT2) += cmd_ext2.o

--- a/common/cmd_disable_jtag.c
+++ b/common/cmd_disable_jtag.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <common.h>
+#include <command.h>
+
+#include <asm/io.h>
+#include <asm/arch/clk.h>
+#include <asm/arch/sys_proto.h>
+#include <asm/arch/hardware.h>
+
+#define DAP_ENABLE_MASK 0x7F
+#define JTAG_CHAIN_DISABLE 0x00800000
+
+static void write_debug_disable()
+{
+  // See: https://www.xilinx.com/support/answers/64275.html
+
+  unsigned int control = readl(&devcfg_base->ctrl);
+
+  control &= ~DAP_ENABLE_MASK;
+  control |= JTAG_CHAIN_DISABLE;
+
+  writel(control, &devcfg_base->ctrl);
+}
+
+int do_disable_jtag(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
+{
+  write_debug_disable(); 
+  return CMD_RET_SUCCESS;
+}
+/***************************************************/
+
+U_BOOT_CMD(
+  disable_jtag, CONFIG_SYS_MAXARGS, 0, do_disable_jtag,
+  "Disables JTAG",
+  "Writes control register which disable JTAG."
+);

--- a/common/cmd_enable_jtag.c
+++ b/common/cmd_enable_jtag.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <common.h>
+#include <command.h>
+
+#include <asm/io.h>
+#include <asm/arch/clk.h>
+#include <asm/arch/sys_proto.h>
+#include <asm/arch/hardware.h>
+
+#define DAP_ENABLE_MASK 0x7F
+#define JTAG_CHAIN_DISABLE 0x00800000
+
+static void write_debug_enable()
+{
+  // See: https://www.xilinx.com/support/answers/64275.html
+
+  unsigned int control = readl(&devcfg_base->ctrl);
+
+  control |=  DAP_ENABLE_MASK;
+  control &= ~JTAG_CHAIN_DISABLE;
+
+  writel(control, &devcfg_base->ctrl);
+}
+
+int do_enable_jtag(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
+{
+  write_debug_enable(); 
+  return CMD_RET_SUCCESS;
+}
+/***************************************************/
+
+U_BOOT_CMD(
+  enable_jtag, CONFIG_SYS_MAXARGS, 0, do_enable_jtag,
+  "Re-enables JTAG",
+  "Writes control register which re-enables JTAG."
+);

--- a/include/configs/piksiv3_failsafe.h
+++ b/include/configs/piksiv3_failsafe.h
@@ -42,6 +42,22 @@
      CONFIG_IMAGE_SET_OFFSET_STANDARD_A,  \
      CONFIG_IMAGE_SET_OFFSET_STANDARD_B}
 
+#define CONFIG_DISABLE_ZYNQ_DEBUG
+
+#define CONFIG_PREBOOT                          \
+  "echo Erasing flash...; "                     \
+  "if sf probe && "                             \
+  "   sf erase 0x0300000 0x1c00000 && "         \
+  "   sf erase 0x2000000 0x1c00000; "           \
+  "then "                                       \
+  "   echo Enabling JTAG...; "                  \
+  "   enable_jtag; "                            \
+  "else "                                       \
+  "   echo Flash erase failed, resetting...; "  \
+  "   sleep 1; "                                \
+  "   reset; "                                  \
+  "fi"
+
 /* CPU clock */
 #ifndef CONFIG_CPU_FREQ_HZ
 # define CONFIG_CPU_FREQ_HZ 800000000
@@ -246,6 +262,8 @@
 #undef CONFIG_BOOTM_NETBSD
 
 #define CONFIG_CMD_IMAGE_SET
+#define CONFIG_CMD_ENABLE_JTAG
+#define CONFIG_CMD_DISABLE_JTAG
 
 #define CONFIG_SYS_HZ     1000
 

--- a/include/configs/piksiv3_prod.h
+++ b/include/configs/piksiv3_prod.h
@@ -99,6 +99,8 @@
 
 #define CONFIG_BOOTCOMMAND		""
 
+#define CONFIG_DISABLE_ZYNQ_DEBUG
+
 #define CONFIG_PREBOOT
 #define CONFIG_BOOTDELAY		0 /* -1 to Disable autoboot */
 #define CONFIG_SYS_LOAD_ADDR	0 /* default? */


### PR DESCRIPTION
For DEVC-290 (https://swift-nav.atlassian.net/browse/DEVC-290) make sure we disable JTAG during boot, and make sure that the failsafe bootloader can erase flash before enabling JTAG.