### PR TITLE
Erase image meta in addition to image data [DEVC-290]

### DIFF
--- a/include/configs/piksiv3_failsafe.h
+++ b/include/configs/piksiv3_failsafe.h
@@ -42,7 +42,7 @@
      CONFIG_IMAGE_SET_OFFSET_STANDARD_A,  \
      CONFIG_IMAGE_SET_OFFSET_STANDARD_B}
 
-//#define CONFIG_DISABLE_ZYNQ_DEBUG
+/*#define CONFIG_DISABLE_ZYNQ_DEBUG*/
 
 #define CONFIG_PREBOOT                          \
   "echo Erasing flash...; "                     \

--- a/include/configs/piksiv3_failsafe.h
+++ b/include/configs/piksiv3_failsafe.h
@@ -42,7 +42,7 @@
      CONFIG_IMAGE_SET_OFFSET_STANDARD_A,  \
      CONFIG_IMAGE_SET_OFFSET_STANDARD_B}
 
-#define CONFIG_DISABLE_ZYNQ_DEBUG
+//#define CONFIG_DISABLE_ZYNQ_DEBUG
 
 #define CONFIG_PREBOOT                          \
   "echo Erasing flash...; "                     \

--- a/include/configs/piksiv3_failsafe.h
+++ b/include/configs/piksiv3_failsafe.h
@@ -44,19 +44,30 @@
 
 /*#define CONFIG_DISABLE_ZYNQ_DEBUG*/
 
-#define CONFIG_PREBOOT                          \
-  "echo Erasing flash...; "                     \
-  "if sf probe && "                             \
-  "   sf erase 0x0300000 0x1c00000 && "         \
-  "   sf erase 0x2000000 0x1c00000; "           \
-  "then "                                       \
-  "   echo Enabling JTAG...; "                  \
-  "   enable_jtag; "                            \
-  "else "                                       \
-  "   echo Flash erase failed, resetting...; "  \
-  "   sleep 1; "                                \
-  "   reset; "                                  \
+#define CONFIG_PREBOOT                                 \
+  "echo Erasing flash...; "                            \
+  "if sf probe                                    && " \
+  "   echo Erasing standard partition A header... && " \
+  "   sf erase 0x0180000 0x0040000                && " \
+  "   echo Erasing standard partition B header... && " \
+  "   sf erase 0x01C0000 0x0040000                && " \
+  "   echo Erasing standard SPL A partition...    && " \
+  "   sf erase 0x0280000 0x0040000                && " \
+  "   echo Erasing standard SPL B partition...    && " \
+  "   sf erase 0x02C0000 0x0040000                && " \
+  "   echo Erasing standard A image partition...  && " \
+  "   sf erase 0x0300000 0x1c00000                && " \
+  "   echo Erasing standard B image partition...  && " \
+  "   sf erase 0x2000000 0x1c00000; "                  \
+  "then "                                              \
+  "   echo Enabling JTAG...; "                         \
+  "   enable_jtag; "                                   \
+  "else "                                              \
+  "   echo Flash erase failed, resetting...; "         \
+  "   sleep 1; "                                       \
   "fi"
+
+/*"   reset; "                                  \*/
 
 /* CPU clock */
 #ifndef CONFIG_CPU_FREQ_HZ

--- a/include/configs/piksiv3_failsafe.h
+++ b/include/configs/piksiv3_failsafe.h
@@ -63,11 +63,18 @@
   "   echo Enabling JTAG...; "                         \
   "   enable_jtag; "                                   \
   "else "                                              \
-  "   echo Flash erase failed, resetting...; "         \
+  "   echo Flash erase failed, resetting in 5s...; "   \
   "   sleep 1; "                                       \
-  "fi"
-
-/*"   reset; "                                  \*/
+  "   echo Flash erase failed, resetting in 4s...; "   \
+  "   sleep 1; "                                       \
+  "   echo Flash erase failed, resetting in 3s...; "   \
+  "   sleep 1; "                                       \
+  "   echo Flash erase failed, resetting in 2s...; "   \
+  "   sleep 1; "                                       \
+  "   echo Flash erase failed, resetting in 1s...; "   \
+  "   sleep 1; "                                       \
+  "   reset; "                                         \
+  "fi"                                                 \
 
 /* CPU clock */
 #ifndef CONFIG_CPU_FREQ_HZ

--- a/include/configs/piksiv3_prod.h
+++ b/include/configs/piksiv3_prod.h
@@ -99,7 +99,7 @@
 
 #define CONFIG_BOOTCOMMAND		""
 
-#define CONFIG_DISABLE_ZYNQ_DEBUG
+//#define CONFIG_DISABLE_ZYNQ_DEBUG
 
 #define CONFIG_PREBOOT
 #define CONFIG_BOOTDELAY		0 /* -1 to Disable autoboot */

--- a/include/configs/piksiv3_prod.h
+++ b/include/configs/piksiv3_prod.h
@@ -99,7 +99,7 @@
 
 #define CONFIG_BOOTCOMMAND		""
 
-//#define CONFIG_DISABLE_ZYNQ_DEBUG
+/*#define CONFIG_DISABLE_ZYNQ_DEBUG*/
 
 #define CONFIG_PREBOOT
 #define CONFIG_BOOTDELAY		0 /* -1 to Disable autoboot */


### PR DESCRIPTION
Erase image meta-data when booting failsafe mode, also leave JTAG enabled for now.